### PR TITLE
Fix clearing sessions command after upgrade

### DIFF
--- a/_includes/manuals/1.20/3.6_upgrade.md
+++ b/_includes/manuals/1.20/3.6_upgrade.md
@@ -134,7 +134,7 @@ migration script again, it should produce no errors or output:
 You should clear the cache and the existing sessions:
 
     foreman-rake tmp:cache:clear
-    foreman-rake tmp:sessions:clear
+    foreman-rake db:sessions:clear
 
 ##### Step 3 (B) - OpenStack and Rackspace compute resource users
 


### PR DESCRIPTION
It looks like the documentation was fixed in #1180 but the wrong command was reintroduced in 1.20.